### PR TITLE
Add additional tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,11 @@ version = "0.1.0"
 authors = ["Carl Lerche <me@carllerche.com>"]
 
 [dependencies]
-futures = { git = "https://github.com/alexcrichton/futures-rs" }
-tokio-core = { git = "https://github.com/tokio-rs/tokio-core" }
+futures = "0.1.4"
+tokio-core = "0.1.1"
 bytes = { git = "https://github.com/carllerche/bytes" }
 byteorder = "0.5"
 
 [dev-dependencies]
 fixture-io = { git = "https://github.com/carllerche/fixture-io" }
 
-[replace]
-"tokio-core:0.1.0" = { git = "https://github.com/tokio-rs/tokio-core" }
-"futures:0.1.3" = { git = "https://github.com/alexcrichton/futures-rs" }

--- a/src/codec/length_delimited.rs
+++ b/src/codec/length_delimited.rs
@@ -112,10 +112,12 @@ impl<T: AsyncRead> Decoder<T> {
 
         loop {
             if self.buf.len() >= head_len {
+                // Enough data has been buffered to process the head
+                
                 // Skip the required bytes
                 self.buf.advance(self.builder.length_field_offset);
-
-                // Enough data has been buffered to process the head
+                
+                // match endianess
                 let n = match self.builder.length_field_order {
                     ByteOrder::BigEndian => {
                         self.buf.get_uint::<BigEndian>(field_len)

--- a/src/codec/length_delimited.rs
+++ b/src/codec/length_delimited.rs
@@ -61,7 +61,7 @@ pub struct Builder {
 
 /// An enumeration of valid byte orders
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-enum ByteOrder {
+pub enum ByteOrder {
     /// Big-endian byte order.
     BigEndian,
 
@@ -463,6 +463,14 @@ impl Builder {
     /// Defaults to `length_field_len + length_field_offset`
     pub fn set_num_skip(mut self, val: usize) -> Self {
         self.num_skip = Some(val);
+        self
+    }
+
+    /// Sets the expected byte order 
+    ///
+    /// Defaults to `ByteOrder::BigEndian`
+    pub fn set_byte_order(mut self, val: ByteOrder) -> Self {
+        self.length_field_order = val;
         self
     }
 


### PR DESCRIPTION
Added basic tests for little endian and max frame size exceeded.

Only question is whether the internal ByteOrder enum should be exposed. Really unfortunate that `byteorder::BigEndian/LittleEndian` are separate enums. If you don't want to expose the internal enum we could just change the method to `set_little_endian` since the default is `BigEndian`

